### PR TITLE
fixing incorrect commas

### DIFF
--- a/scripts/Econ.gd
+++ b/scripts/Econ.gd
@@ -182,13 +182,20 @@ func adjust_individual_tax_rate(num, dir):
 
 # Helper Functions
 func comma_values(val):
-	var pos = val.length() % 3
 	var res = ""
+	#this cuts off the negative sign to allow for proper comma formatting
+	if (val[0] == '-'):
+		val = val.substr(1, -1)
+		# add the negative sign back into the result
+		res += "-"
+		
+	var pos = val.length() % 3
 	
 	for i in range(0, val.length()):
 		if i != 0 && i % 3 == pos:
 			res += ","
 		res += val[i]
+		
 	return res
 
 func adjust_individual_tax_rate_helper(currRate, dir):


### PR DESCRIPTION
I believe I have fixed the bug resulting in commas being displayed incorrectly when numbers are negative. I made some small edits in `Econ.gd` to the `comma_values` function. I tested it in-game by placing down a power plant, a road, a single light residential district, and then as many power plants as I could, in that order. This creates a negative income in the top HUD of around -1,000. It passed this test, but I couldn't really test it more robustly than that without changing game values and stuff. Instead, I mocked up the function in Python line-for-line and tested it that way. It worked for larger numbers. My script is pasted below: 

```
 def commas(val):
    res = ""
    if (val[0] == '-'):
        val = val[1:]
        res += "-"
    pos = len(val) % 3
    for i in range(0, len(val)):
        if i != 0 and i % 3 == pos:
            res += ","
        res += val[i]
    return res

print (commas(str(1000000)))
print (commas(str(-1000000)))
```
The only difference between this logic and the logic in the `comma_values` function in GDScript is the method for doing the substring operation, otherwise all functionality is identical between the two versions. 


