### PR TITLE
Decoupled Stats and Observers and Added Shell for NpcObservers

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -182,6 +182,8 @@ Overlay="*res://ui/Popups/Overlay.tscn"
 Announcer="*res://scripts/Observers/Announcer.gd"
 MissionObserver="*res://scripts/Observers/MissionObserver.gd"
 AchievementObserver="*res://scripts/Observers/AchievementObserver.gd"
+Stats="*res://scripts/Stats.gd"
+NpcObserver="*res://scripts/Observers/NpcObserver.gd"
 
 [display]
 

--- a/scripts/Observers/AchievementObserver.gd
+++ b/scripts/Observers/AchievementObserver.gd
@@ -13,7 +13,7 @@ func createAchievements():
 	toComplete.push_back(goalClass.new('# of Commercial Areas', true, 10, 'Build 10 Commercial Areas', 'Build 10 Commercial Areas', 0))
 	toComplete.push_back(goalClass.new('Money', true, 110000, 'Money Made', 'Make $110,000', 1))
 
-func onNotify(event, stats):
+func onNotify(event):
 	#Fun fact to anyone looking through this code: you can't delete from an array you're looping through in gdscript: https://ask.godotengine.org/77668/what-happens-when-i-remove-an-array-element-isnide-a-for-loop#:~:text=1%20Answer&text=Don't%20loop%20through%20the,loop%20through%20that%20array%20instead.
 	for i in range(toComplete.size()):
 		if toComplete[i].isComplete():

--- a/scripts/Observers/Announcer.gd
+++ b/scripts/Observers/Announcer.gd
@@ -3,13 +3,6 @@ extends Node
 var observers = Array()
 var numOfObservers = 0
 
-# Stats that observers care about
-var stats = {
-	'# of Residential Areas': 0, 
-	'# of Commercial Areas': 0,
-	'Money': 0
-}
-
 func addObserver(observer):
 	observers.append(observer)
 	numOfObservers = numOfObservers + 1
@@ -18,22 +11,8 @@ func removeObserver(observer):
 	observers.erase(observer)
 	numOfObservers = numOfObservers - 1
 
-func updateStats(event):
-	if event.eventName == "Added Tile":
-		if event.eventDescription == "Added Resedential Area":
-			stats['# of Residential Areas'] += event.eventValue
-		elif event.eventDescription == "Added Commercial Area":
-			stats['# of Commercial Areas'] += event.eventValue
-	elif event.eventName == "Removed Tile":
-		if event.eventDescription == "Removed Residential Area":
-			stats['# of Residential Areas'] -= event.eventValue
-		elif event.eventDescription == "Removed Commercial Area":
-			stats['# of Commercial Areas'] -= event.eventValue
-	elif event.eventName == "Money":
-		stats['Money'] = event.eventValue
-
 func notify(event):
-	updateStats(event)
+	Stats.updateStats(event)
 	# Time to announce to all the observers
 	for i in numOfObservers:
-		observers[i].onNotify(event, stats)
+		observers[i].onNotify(event)

--- a/scripts/Observers/Goal.gd
+++ b/scripts/Observers/Goal.gd
@@ -22,6 +22,6 @@ func _init(_varToCheck, _greaterThan, _constGoal, _achievementName, _achievement
 
 func isComplete():
 	if greaterThan:
-		return Announcer.stats[varToCheck] >= constGoal
+		return Stats.getStat(varToCheck) >= constGoal
 	else:
-		return Announcer.stats[varToCheck] <= constGoal
+		return Stats.getStat(varToCheck) <= constGoal

--- a/scripts/Observers/MissionObserver.gd
+++ b/scripts/Observers/MissionObserver.gd
@@ -24,7 +24,7 @@ func createMissions():
 	mission2.append(goalClass.new('Money', true, 999999999999, 'We\'re rich!', 'Make $999,999,999,999', 1))
 	missions.append(mission2)
 
-func onNotify(event, stats):
+func onNotify(event):
 	# Whenever we're notified, check if we've completed any of our missions
 	for i in range(missions[0].size()):
 		if missions[0][i].isComplete():
@@ -36,7 +36,7 @@ func onNotify(event, stats):
 
 func unlock(miss, missNum):
 	# Mark as finished
-	print("Mission Complete: " + miss.achievementName)
+	#print("Mission Complete: " + miss.achievementName)
 	toDelete.append(missNum)
 	
 	#Find the right node, change the color
@@ -63,7 +63,7 @@ func deleteGoals():
 func checkIfDone():
 	# Check if all missions in this group our complete
 	if missions[0].empty():
-		print("All Missions Complete in Group #" + str(missionIndex))
+		#print("All Missions Complete in Group #" + str(missionIndex))
 		missionIndex += 1
 		missions.remove(0) # Keep new set of missions at beginning
 		#FIXME: This is to prevent crashing when missions are done, will eventually want to figure out what to do in that case
@@ -71,7 +71,8 @@ func checkIfDone():
 			createMissions()
 		displayNewMissions()
 		#FIXME: When events are updates, replace "" with something better
-		onNotify("", Announcer.stats) #Check onNotify to see if new goals are complete
+		onNotify("") #Check onNotify to see if new goals are complete
+		Announcer.notify(Event.new("Completed Mission", "Completed Mission", missionIndex - 1)) # Mission index - 1 because it's the last group
 
 func hoverMission(index):
 	# Currently useless while I figure out hover text

--- a/scripts/Observers/NpcObserver.gd
+++ b/scripts/Observers/NpcObserver.gd
@@ -1,0 +1,18 @@
+extends "res://scripts/Observers/Observer.gd"
+#Handles SFX
+
+#export var sfxPlayer : AudioStreamPlayer
+
+func onNotify(event):
+	# Plays some banger royalty free construction sfx
+	if event.eventName == "Completed Mission":
+		if event.eventValue == 0:
+			print("Mission 0 Dialogue Start")
+			triggerDialogue("Inputs here")
+
+func triggerDialogue(dialogue):
+	pass # Happens when dialogue is triggered
+
+func initializeNPCs():
+	pass # Happens once at the start of the program
+	

--- a/scripts/Observers/Observer.gd
+++ b/scripts/Observers/Observer.gd
@@ -2,5 +2,5 @@ class_name Observer extends Node
 # Credit: https://gameprogrammingpatterns.com/observer.html
 # Add your observer to initObservers in start_map
 
-func onNotify(event, stats): #Essentially a virtual function
+func onNotify(event): #Essentially a virtual function
 	pass

--- a/scripts/Observers/SfxObserver.gd
+++ b/scripts/Observers/SfxObserver.gd
@@ -3,7 +3,7 @@ class_name SfxObserver extends "res://scripts/Observers/Observer.gd"
 
 #export var sfxPlayer : AudioStreamPlayer
 
-func onNotify(event, stats):
+func onNotify(event):
 	# Plays some banger royalty free construction sfx
 	if event.eventName == "Added Tile":
 		if event.eventDescription == "Added Resedential Area" || event.eventDescription == "Added Commercial Area":

--- a/scripts/Stats.gd
+++ b/scripts/Stats.gd
@@ -1,0 +1,24 @@
+extends Node
+
+var stats = {
+	'# of Residential Areas': 0, 
+	'# of Commercial Areas': 0,
+	'Money': 0
+}
+
+func getStat(name):
+	return stats[name]
+
+func updateStats(event):
+	if event.eventName == "Added Tile":
+		if event.eventDescription == "Added Resedential Area":
+			stats['# of Residential Areas'] += event.eventValue
+		elif event.eventDescription == "Added Commercial Area":
+			stats['# of Commercial Areas'] += event.eventValue
+	elif event.eventName == "Removed Tile":
+		if event.eventDescription == "Removed Residential Area":
+			stats['# of Residential Areas'] -= event.eventValue
+		elif event.eventDescription == "Removed Commercial Area":
+			stats['# of Commercial Areas'] -= event.eventValue
+	elif event.eventName == "Money":
+		stats['Money'] = event.eventValue

--- a/scripts/start_map.gd
+++ b/scripts/start_map.gd
@@ -49,6 +49,10 @@ func initObservers():
 	Announcer.addObserver(get_node("/root/AchievementObserver"))
 	AchievementObserver.createAchievements()
 	
+	#Add npc observers
+	Announcer.addObserver(get_node("/root/NpcObserver"))
+	NpcObserver.initializeNPCs()
+	
 	#Add mission observer
 	var missObs = get_node("/root/MissionObserver")
 	Announcer.addObserver(missObs)


### PR DESCRIPTION
Hey just a quick pull request, just solving two main issues. One, the statistics that the observers were using may be helpful for other parts of the code, so I wanted to decouple them so that they'd be accessible anywhere. The only other main change of this PR is that I made a shell for the NPC Observer for Rafaela and Edward. The actual functionality is not there yet and it just triggers whenever a set of missions is completed.